### PR TITLE
bugfix #398 total number of jobs in title from landing page

### DIFF
--- a/src/pages/landing/components/title/title.component.jsx
+++ b/src/pages/landing/components/title/title.component.jsx
@@ -3,14 +3,26 @@ import './title.style.scss';
 
 import { useSelector } from 'react-redux';
 
-export const Title = ({ allJobs }) => {
+export const Title = ({ allJobs, totalJobs }) => {
   const isRomania = useSelector((state) => state.query.country);
   const totalCompanies = useSelector((state) => state.jobs.totalCompanies);
 
   return (
-    <section className='title'>
-      <h1>Găsește-ți <span className='text--orange'>jobul dorit</span> acum</h1>
-      {allJobs && totalCompanies ? <p className='description'>Avem <span className='bold'>{allJobs} </span>de oportunități de la <span className='bold'>{totalCompanies}</span> firme {isRomania ? 'în România' : ''}</p> : ''}
+    <section className="title">
+      <h1>
+        Găsește-ți <span className="text--orange">jobul dorit</span> acum
+      </h1>
+      {allJobs && totalCompanies ? (
+        <p className="description">
+          Avem <span className="bold">{isRomania ? allJobs : totalJobs} </span>
+          de oportunități de la <span className="bold">
+            {totalCompanies}
+          </span>{' '}
+          firme {isRomania ? 'în România' : 'în toate țările'}
+        </p>
+      ) : (
+        ''
+      )}
     </section>
   );
 };

--- a/src/pages/landing/components/title/title.component.jsx
+++ b/src/pages/landing/components/title/title.component.jsx
@@ -15,10 +15,8 @@ export const Title = ({ allJobs, totalJobs }) => {
       {allJobs && totalCompanies ? (
         <p className="description">
           Avem <span className="bold">{isRomania ? allJobs : totalJobs} </span>
-          de oportunități de la <span className="bold">
-            {totalCompanies}
-          </span>{' '}
-          firme {isRomania ? 'în România' : 'în toate țările'}
+          de oportunități {isRomania ? 'în România' : 'în toate țările'} de la{' '}
+          <span className="bold">{totalCompanies}</span> firme
         </p>
       ) : (
         ''

--- a/src/pages/landing/landing.component.jsx
+++ b/src/pages/landing/landing.component.jsx
@@ -7,11 +7,16 @@ import { Search } from '../../components/search/search.component';
 import {
   clearJobs,
   updateTotalCompanies,
-  updateTotalRomania
+  updateTotalRomania,
+  updateTotal
 } from '../../state/jobs.slice';
 import { setPageToOne, updatCity, updateCounty } from '../../state/query.slice';
 import { createQueryString } from '../../utils/create-query-string';
-import { getTotalCompanies, getTotalRomania } from '../../utils/get-data';
+import {
+  getTotalCompanies,
+  getTotalRomania,
+  getAllJobs
+} from '../../utils/get-data';
 import { Banner } from './components/banner/banner.component';
 import { Rocket } from './components/rocket/rocket.component';
 import { Title } from './components/title/title.component';
@@ -23,12 +28,16 @@ export const LandingPage = () => {
   const queries = useSelector((state) => state.query);
 
   const allJobs = useSelector((state) => state.jobs.allJobs);
+  const totalJobs = useSelector((state) => state.jobs.total);
 
   useEffect(() => {
     dispatch(setPageToOne());
     dispatch(updatCity(''));
     dispatch(updateCounty(''));
     dispatch(clearJobs());
+    getAllJobs().then((totalJobs) => {
+      dispatch(updateTotal(totalJobs));
+    });
     getTotalRomania().then((totalRomania) => {
       dispatch(updateTotalRomania(totalRomania));
     });
@@ -51,7 +60,7 @@ export const LandingPage = () => {
       <main>
         <section className="main-wrapper">
           <div className="main">
-            <Title allJobs={allJobs} />
+            <Title allJobs={allJobs} totalJobs={totalJobs} />
             <Search handleClick={handleSearchClick} queries={queries} />
           </div>
           <Rocket />


### PR DESCRIPTION
Issue #398 

Initial a aratat doar numarul de joburi din Romania in titlu pentru ca default selection era Romania, acum, cand selectezi "Toate", se modifica si arata numarul de joburi din toate tarile.


**Modificare la text:**

"Avem 18789 de oportunități de la 720 firme **în România**" 
a devenit 
"Avem 18789 de oportunități **în România** de la 720 firme"

iar

"Avem 28655 de oportunități de la 720 firme **în toate țările**" 
a devenit
"Avem 28805 de oportunități **în toate țările** de la 720 firme"

ca sa fie mai clar faptul ca numarul total de firme nu este pentru oportunitatile din Romania sau doar din restul tarilor, ci numarul total de firme, neavand la dispozitie doar numarul de firme din Romania


https://github.com/peviitor-ro/search-engine/assets/28507505/16bea754-eb39-4959-b5c0-7e3466ebb198

