### PR TITLE
story-352-change-api-homepage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,11 +11,9 @@ const container = document.getElementById('root');
 const root = createRoot(container);
 
 root.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
-  </React.StrictMode>
+  <Provider store={store}>
+    <App />
+  </Provider>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/pages/landing/landing.component.jsx
+++ b/src/pages/landing/landing.component.jsx
@@ -12,11 +12,7 @@ import {
 } from '../../state/jobs.slice';
 import { setPageToOne, updatCity, updateCounty } from '../../state/query.slice';
 import { createQueryString } from '../../utils/create-query-string';
-import {
-  getTotalCompanies,
-  getTotalRomania,
-  getAllJobs
-} from '../../utils/get-data';
+import { getNumberOfJobsAndCompanies } from '../../utils/get-data';
 import { Banner } from './components/banner/banner.component';
 import { Rocket } from './components/rocket/rocket.component';
 import { Title } from './components/title/title.component';
@@ -35,14 +31,10 @@ export const LandingPage = () => {
     dispatch(updatCity(''));
     dispatch(updateCounty(''));
     dispatch(clearJobs());
-    getAllJobs().then((totalJobs) => {
-      dispatch(updateTotal(totalJobs));
-    });
-    getTotalRomania().then((totalRomania) => {
-      dispatch(updateTotalRomania(totalRomania));
-    });
-    getTotalCompanies().then((totalCompanies) => {
-      dispatch(updateTotalCompanies(totalCompanies));
+    getNumberOfJobsAndCompanies().then((data) => {
+      dispatch(updateTotal(data.jobs.all));
+      dispatch(updateTotalRomania(data.jobs.ro));
+      dispatch(updateTotalCompanies(data.companies));
     });
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/utils/get-data.js
+++ b/src/utils/get-data.js
@@ -1,39 +1,50 @@
-import { createQueryString } from "./create-query-string";
-import { mapApiData } from "./map-api-data";
+import { createQueryString } from './create-query-string';
+import { mapApiData } from './map-api-data';
 
-const API_VERSION = 'v3'
+const API_VERSION = 'v3';
 
 export const getData = (queryParams) => {
-    return fetch(`https://api.peviitor.ro/${API_VERSION}/search/?${createQueryString(queryParams)}`)
-        .then((response) => response.json())
-        .then((data) => {
-            return {
-                jobs: mapApiData(data.response.docs),
-                total: data.response.numFound
-            };
-        });
-}
+  return fetch(
+    `https://api.peviitor.ro/${API_VERSION}/search/?${createQueryString(
+      queryParams
+    )}`
+  )
+    .then((response) => response.json())
+    .then((data) => {
+      return {
+        jobs: mapApiData(data.response.docs),
+        total: data.response.numFound
+      };
+    });
+};
 
 export const getTotalRomania = () => {
-    return fetch(`https://api.peviitor.ro/${API_VERSION}/search/?country=România`)
-        .then((response) => response.json())
-        .then((data) => {
-            return data.response.numFound;
-        });
-}
+  return fetch(`https://api.peviitor.ro/${API_VERSION}/search/?country=România`)
+    .then((response) => response.json())
+    .then((data) => {
+      return data.response.numFound;
+    });
+};
 
 export const getAllJobs = () => {
-    return fetch(`https://api.peviitor.ro/${API_VERSION}/search/`)
-        .then((response) => response.json())
-        .then((data) => {
-            return data.response.numFound;
-        });
-}
+  return fetch(`https://api.peviitor.ro/${API_VERSION}/search/`)
+    .then((response) => response.json())
+    .then((data) => {
+      return data.response.numFound;
+    });
+};
 
 export const getTotalCompanies = () => {
-    return fetch(`https://api.peviitor.ro/${API_VERSION}/logo/`)
-        .then((response) => response.json())
-        .then((data) => {
-            return data.companies.length;
-        })
-}
+  return fetch(`https://api.peviitor.ro/${API_VERSION}/logo/`)
+    .then((response) => response.json())
+    .then((data) => {
+      return data.companies.length;
+    });
+};
+export const getNumberOfJobsAndCompanies = () => {
+  return fetch(`https://api.peviitor.ro/${API_VERSION}/totals/`)
+    .then((response) => response.json())
+    .then((data) => {
+      return data;
+    });
+};


### PR DESCRIPTION
### Changed the api from which the landing component retrieves the number of companies and jobs to: https://api.peviitor.ro/v3/totals/ Issue #352 

- [x] Created a new function in get-data for this, that consumes the API https://api.peviitor.ro/v3/totals/
- [x] Removed the unused functions from the landing component to avoid errors in production.
- [x] Imported the function in the landing component.
- [x] Used it at page load to retrieve the numbers(in useEffect)
- [x] removed _<React.StrictMode>_ from index.js, which is used for development purposes, because when it was used, it triggered double rendering and triggered double usage of the useEffect, hence double API call in the landing component, longer loading time in Prod. It's also the reason why the app in production might issue unnecessary warnings and errors.

Screenshot of before and after removal of strict mode:

![api-call-with-strict](https://github.com/peviitor-ro/search-engine/assets/28507505/773ec7f4-f0ea-4837-9230-73d66889f7a9)
![api-call-without-strict](https://github.com/peviitor-ro/search-engine/assets/28507505/660602fa-9feb-41a7-bb3c-81832418ffd1)

Screenshot of information regarding **safe removal of <React.StrictMode>**

![chat-strict](https://github.com/peviitor-ro/search-engine/assets/28507505/90023bbd-8fe3-4a42-85ed-40659e1a7765)
![chat-strict-recommend](https://github.com/peviitor-ro/search-engine/assets/28507505/2ffe1067-2e9c-4ed2-873e-d89a9e9923e9)


