### PR TITLE
Auto lock in uniquely filtered location result

### DIFF
--- a/src/components/search/search.component.jsx
+++ b/src/components/search/search.component.jsx
@@ -151,7 +151,6 @@ export const Search = (props) => {
           setSelectedLocation(uniqueResults[0]);
           handleSelection(uniqueResults[0]);
           setUniqueEstablished(true);
-          console.log('UniqueEstablished', uniqueEstablished);
         } else setUniqueEstablished(false);
       }
     } else {

--- a/src/components/search/search.style.scss
+++ b/src/components/search/search.style.scss
@@ -52,6 +52,7 @@
     }
     .clear {
       all: unset;
+      background-color: lightgray;
       position: absolute;
       right: 2px;
       padding: 5px;
@@ -65,7 +66,7 @@
 
       &:hover {
         transition: all ease 200ms;
-        background-color: lightgray;
+        background-color: darkgray;
       }
     }
 
@@ -98,6 +99,13 @@
         box-sizing: border-box;
         text-transform: lowercase;
         text-transform: capitalize;
+      }
+
+      .locked-input {
+        background-color: rgb(224, 141, 33, 0.1);
+        padding: 5px;
+        margin: 9px;
+        border-radius: 9px;
       }
 
       .country:focus-within,


### PR DESCRIPTION
Adresses issue #433 where the user misinterprets a simple type in with an actual selection

Solves it by locking in the result location if by typing, a unique location is filtered.

When the user types in and searches for a location and reaches a unique result, that location is locked in and signaled with a colored background. The user can only remove it via "x" and then search for another location.

TESTING can be done here:  https://peviitor-rb.web.app/

https://github.com/peviitor-ro/search-engine/assets/28507505/a4734fa6-7915-4fac-b409-b03fed58ebfb


