### PR TITLE
bugfix: github icon href fix

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -34,7 +34,7 @@ const Footer = () => {
             </a>
             <a
               className="icon"
-              href="https://github.com/peviitor-ro/ui-js/issues"
+              href="https://github.com/peviitor-ro/oportunitatisicariere/issues"
               target="_blank"
               rel="noreferrer"
               title="GitHub"


### PR DESCRIPTION
changed github icon href from
https://github.com/peviitor-ro/search-engine/issues
to
https://github.com/peviitor-ro/oportunitatisicariere/issues