### PR TITLE
Add diacritical signs for buttons

### DIFF
--- a/src/components/Results.jsx
+++ b/src/components/Results.jsx
@@ -105,7 +105,7 @@ const Results = () => {
                 className="self-center cursor-pointer"
                 onClick={handleRemoveAllFilters}
               >
-                Sterge filtre
+                Șterge filtre
               </button>
             </div>
           )}
@@ -161,7 +161,7 @@ const Results = () => {
                 className="flex justify-center items-center px-8 py-3 rounded-full  bg-background_green text-white font-medium text-lg leading-6 hover:shadow-button_shadow cursor-pointer mx-auto my-12"
                 onClick={fetchMoreData}
               >
-                Incarca mai multe
+                Încarcă mai multe
               </button>
             ))}
         </>


### PR DESCRIPTION
I've corrected the spelling for the buttons:
![image](https://github.com/user-attachments/assets/ce62a907-aea2-494e-8eda-56dd5e1390ce)
![image](https://github.com/user-attachments/assets/2a795424-df5d-48e3-8dad-1c513fed1ec2)
