### PR TITLE
Fix close icon on the results page

### DIFF
--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -179,6 +179,7 @@ const Search = () => {
   function handleCloseIcon() {
     setText("");
     updateUrlParams({ q: null });
+    contextSetQ(['']);
   }
 
   //function to remove diacritics


### PR DESCRIPTION

* Bug: clicking the close icon was deleting
the input word and updating the URL, but the
results weren't updating.
* Trigger React's re-render to fix it.
