### PR TITLE
Bug: Fixed diacritics and spelling errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "react-search-engine",
       "version": "0.1.0",
       "dependencies": {
-        "@floating-ui/react": "^0.27.4",
+        "@floating-ui/react": "^0.27.6",
         "@reduxjs/toolkit": "^2.2.2",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
@@ -2586,9 +2586,10 @@
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.4.tgz",
-      "integrity": "sha512-05mXdkUiVh8NCEcYKQ2C9SV9IkZ9k/dFtYmaEIN2riLv80UHoXylgBM76cgPJYfLJM3dJz7UE5MOVH0FypMd2Q==",
+      "version": "0.27.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.6.tgz",
+      "integrity": "sha512-9GLOPbW8jTeboR2ar9uMMUDUZjpTLscUvOjNvRw2EgppgoLHLUh/P/OW9evULosnvDjhYf2Gwk/gMOP9KvXD2A==",
+      "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.2",
         "@floating-ui/utils": "^0.2.9",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@floating-ui/react": "^0.27.4",
+    "@floating-ui/react": "^0.27.6",
     "@reduxjs/toolkit": "^2.2.2",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/src/pages/TermsOfUse.jsx
+++ b/src/pages/TermsOfUse.jsx
@@ -1,4 +1,4 @@
-import React,  { useEffect } from "react";
+import React, { useEffect } from "react";
 import HomeLink from "../components/CustomLinks";
 import Layout from "../components/Layout";
 
@@ -16,32 +16,32 @@ const TermsOfUse = () => {
                     Condiții de utilizare
                 </h1>
             </header>
-    
+
             <article className="font-PoppinsRegular flex flex-col w-full">
                 <section className="pt-12 bg-white/20 w-full flex flex-col items-center" aria-labelledby="terms-intro-heading">
                     <h2 className="text-lg leading-6 text-left mb-4 w-3/4"><strong>TERMENI ŞI CONDIŢII DE UTILIZARE</strong></h2>
-                    <p className="mb-4 w-3/4">Prin utilizarea acestui site,  
-                        <HomeLink/>
-                        , sunteţi de acord cu termenii şi condiţiile de utilizare meţionate în aceasta pagină. Accesul şi utilizarea acestui site sunt supuse următorilor termeni şi condiţii de utilizare şi tuturor legilor şi 
-                        regulamentelor aplicabile. Accesând şi utilizând site-ul, acceptaţi, fără limitări sau calificări, aceşti termeni şi condiţii şi luaţi la cunoştinţă că orice alte acorduri între dumneavoastră şi terţe 
+                    <p className="mb-4 w-3/4">Prin utilizarea acestui site,
+                        <HomeLink />
+                        , sunteţi de acord cu termenii şi condiţiile de utilizare meţionate în aceasta pagină. Accesul şi utilizarea acestui site sunt supuse următorilor termeni şi condiţii de utilizare şi tuturor legilor şi
+                        regulamentelor aplicabile. Accesând şi utilizând site-ul, acceptaţi, fără limitări sau calificări, aceşti termeni şi condiţii şi luaţi la cunoştinţă că orice alte acorduri între dumneavoastră şi terţe
                         părţi cu privire la utilizarea site-ului sunt înlocuite prin prevederile prezentului document. Dacă nu sunteţi de acord sau nu acceptaţi, fără limitări sau calificări, Termenii şi
-                         Condiţiile de Utilizare ale acestui site, vă rugăm să părăsiţi această platformă.
+                        Condiţiile de Utilizare ale acestui site, vă rugăm să părăsiţi această platformă.
                     </p>
-                    <p className="mb-4 w-3/4">Prin continuarea utilizării serviciilor oferite de site-ul 
-                        <HomeLink/> confirmaţi că sunteţi de acord cu Termenii şi Condiţiile de Utilizare mai jos menţionaţi.
+                    <p className="mb-4 w-3/4">Prin continuarea utilizării serviciilor oferite de site-ul
+                        <HomeLink /> confirmaţi că sunteţi de acord cu Termenii şi Condiţiile de Utilizare mai jos menţionaţi.
                     </p>
                 </section>
-                   
-                <section  className="pt-12 w-full flex flex-col items-center" aria-labelledby="general-terms-heading">
+
+                <section className="pt-12 w-full flex flex-col items-center" aria-labelledby="general-terms-heading">
                     <h2 className="text-lg leading-6 text-left mb-4 w-3/4">
                         <strong>TERMENI GENERALI</strong>
                     </h2>
                     <ol className="mb-8 w-3/4 list-inside">
-                        <li className="mb-4">Site-ul <HomeLink/>, este proprietatea ASOCIAȚIEI OPORTUNITĂȚI ȘI CARIERE cu sediul în Zimbor numarul 215, județul Sălaj. Accesarea acestui site ori a 
-                            oricărei părţi din acest site presupune acordul tacit cu termenii ce urmează. Acordul de utilizare îşi produce efectele între dumneavoastră şi ASOCIAȚIA OPORTUNITĂȚI ȘI 
+                        <li className="mb-4">Site-ul <HomeLink />, este proprietatea ASOCIAȚIEI OPORTUNITĂȚI ȘI CARIERE cu sediul în Zimbor numărul 215, județul Sălaj. Accesarea acestui site ori a
+                            oricărei părţi din acest site presupune acordul tacit cu termenii ce urmează. Acordul de utilizare îşi produce efectele între dumneavoastră şi ASOCIAȚIA OPORTUNITĂȚI ȘI
                             CARIERE. Acceptarea se consideră tacită şi fără rezerve.
                         </li>
-                        <li className="mb-4"><HomeLink/> poate schimba conţinutul site-ului la orice moment, poate aduce modificări de structură, conţinut şi accesibilitate, poate sista furnizarea 
+                        <li className="mb-4"><HomeLink /> poate schimba conţinutul site-ului la orice moment, poate aduce modificări de structură, conţinut şi accesibilitate, poate sista furnizarea
                             informaţiilor pe site, fără un acord prealabil şi fără vreo notificare către dumneavoastră ori către terţe persoane.
                         </li>
                         <li className="mb-4">Continuarea utilizării site-ului presupune acordul dumneavoastră tacit şi acordul în întregime cu Termenii şi condiţiile
@@ -57,25 +57,25 @@ const TermsOfUse = () => {
                 <section className="pt-12 bg-white/20 w-full flex flex-col items-center" aria-labelledby="content-heading">
                     <h2 className="text-lg leading-6 text-left mb-4 w-3/4"><strong>1. CONŢINUTUL</strong></h2>
                     <ol className="mb-8 w-3/4 [list-style-type:lower-alpha] list-inside">
-                        <li className="mb-4">Conţinutul site-ului este destinat uzului personal, fără scop direct ori indirect comercial. Toate materialele publicate (incluzând, dar fără a se limita la, 
+                        <li className="mb-4">Conţinutul site-ului este destinat uzului personal, fără scop direct ori indirect comercial. Toate materialele publicate (incluzând, dar fără a se limita la,
                             articole, informaţii, fotografii, date, clipuri audio/video – generic numite conţinut) sunt protejate de dispoziţiile legale incidente: Legea nr. 8/1996, cu modificările şi completările
-                            ulterioare – privind dreptul de autor şi drepturile conexe, Legea nr. 84/1998 – privind mărcile şi indicaţiile geografice şi Legea nr. 129/1992, republicată – privind protecţia 
+                            ulterioare – privind dreptul de autor şi drepturile conexe, Legea nr. 84/1998 – privind mărcile şi indicaţiile geografice şi Legea nr. 129/1992, republicată – privind protecţia
                             desenelor şi modelelor. Lipsa menţiunii privind unele texte legale ori dispoziţii incidente nu duc la inaplicabilitatea acestora.
                         </li>
-                        <li className="mb-4">Site-ul şi Conţinutul sunt protejate de Legea drepturilor de autor din România, precum şi de dispoziţiile privitoare la copyright aplicabile 
-                            în alte teritorii decât România. Dumneavoastră nu puteţi copia, stoca, modifica ori transfera cu orice titlu, în parte ori întreg site şi/sau Conţinutul. Exploatarea este liberă, 
+                        <li className="mb-4">Site-ul şi Conţinutul sunt protejate de Legea drepturilor de autor din România, precum şi de dispoziţiile privitoare la copyright aplicabile
+                            în alte teritorii decât România. Dumneavoastră nu puteţi copia, stoca, modifica ori transfera cu orice titlu, în parte ori întreg site şi/sau Conţinutul. Exploatarea este liberă,
                             sub condiţia non-comercialităţii şi respectării termenilor impuşi de către ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE.
                         </li>
-                        <li className="mb-4">Orice formă de copiere, stocare, modificare şi/sau transmitere a Conţinutului este expres interzisă, 
+                        <li className="mb-4">Orice formă de copiere, stocare, modificare şi/sau transmitere a Conţinutului este expres interzisă,
                             fără acordul prealabil şi scris al ASOCIAȚIEI OPORTUNITĂȚI ȘI CARIERE.
                         </li>
                         <li className="mb-4">ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE nu răspunde de eventualele prejudicii, litigii existente, născute ori izvorâte în legătură cu/din copierea, stocarea, modificare
                             ori transferarea întregului ori a unei părţi din Conţinut în orice mediu.
                         </li>
-                        <li className="mb-4">În cazul în care consideraţi că orice material publicat pe acest site oricine altcineva încalcă drepturile de autor sau orice alte drepturi, 
+                        <li className="mb-4">În cazul în care consideraţi că orice material publicat pe acest site oricine altcineva încalcă drepturile de autor sau orice alte drepturi,
                             vă rugăm să ne sesizaţi acest lucru printr-un mesaj trimis la adresa publicată în secţiunea Contact a site-ului sau pe adresa de e-mail aocpeviitor@gmail.com
                         </li>
-                        <li className="mb-4">Vă informăm că ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE îşi va asigura şi impune în mod hotărît recunoaşterea drepturilor de proprietate intelectuală 
+                        <li className="mb-4">Vă informăm că ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE îşi va asigura şi impune în mod hotărît recunoaşterea drepturilor de proprietate intelectuală
                             în conformitate cu legile în vigoare, ajungând dacă este cazul, la acţionarea în judecată a celor vinovaţi de încălcarea dreptului de proprietate intelectuală.
                         </li>
                     </ol>
@@ -84,36 +84,36 @@ const TermsOfUse = () => {
                 <section className="pt-12 w-full flex flex-col items-center" aria-labelledby="copyright-rights">
                     <h2 className="text-lg leading-6 text-left mb-4 w-3/4"><strong>2. DREPTURILE DE AUTOR</strong></h2>
                     <ol className="mb-8 w-3/4 [list-style-type:lower-alpha] list-inside">
-                        <li className="mb-4">Toate drepturile rezervate. ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE acordă permisunea de a utiliza site-ul                         
-                            <HomeLink/> în următoarele condiţii:
+                        <li className="mb-4">Toate drepturile rezervate. ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE acordă permisiunea de a utiliza site-ul
+                            <HomeLink /> în următoarele condiţii:
                         </li>
-                        <li className="mb-4">Sunt interzise copierea, modificarea, expunerea, refolosirea, reproducerea, publicarea, autorizarea, acordarea de licenţă de folosire, 
-                            crearea de lucrări derivate din, sau să transferaţi, să vindeţi sau să folosiţi conţinutul publicat pe acest site, 
-                            materialele protejate prin legile naţionale şi internaţionale de copyright, în alt mod decât cu acordul scris al 
-                            ASOCIAȚIEI OPORTUNITĂȚI ȘI CARIERE precum şi orice modalitate de exploatare a conţinutului site-ului                            
-                            <HomeLink/>, cu excepţia afişării pe ecranul unui computer personal şi imprimarea sau descărcarea, în scop personal şi necomercial, 
-                            a anumitor documente sau informaţii explicit desemnate în acest scop, cu condiţia păstrării nemodificate a tuturor elementelor 
-                            care fac referire la drepturile de proprietate intelectuală, alte drepturi de proprietate şi condiţiile de utilizare ale 
+                        <li className="mb-4">Sunt interzise copierea, modificarea, expunerea, refolosirea, reproducerea, publicarea, autorizarea, acordarea de licenţă de folosire,
+                            crearea de lucrări derivate din, sau să transferaţi, să vindeţi sau să folosiţi conţinutul publicat pe acest site,
+                            materialele protejate prin legile naţionale şi internaţionale de copyright, în alt mod decât cu acordul scris al
+                            ASOCIAȚIEI OPORTUNITĂȚI ȘI CARIERE precum şi orice modalitate de exploatare a conţinutului site-ului
+                            <HomeLink />, cu excepţia afişării pe ecranul unui computer personal şi imprimarea sau descărcarea, în scop personal şi necomercial,
+                            a anumitor documente sau informaţii explicit desemnate în acest scop, cu condiţia păstrării nemodificate a tuturor elementelor
+                            care fac referire la drepturile de proprietate intelectuală, alte drepturi de proprietate şi condiţiile de utilizare ale
                             documentelor sau informaţiilor respective.
                         </li>
-                        <li className="mb-4">Este interzis să folosiţi site-ul 
-                            <HomeLink/> pentru a afişa sau transmite orice fel de material ce are caracter ameninţător, fals, înşelător, abuziv, de hărţuire, 
-                            licenţios, calomniator, vulgar, sau orice alt fel de material care poate constitui sau încuraja un comportament ce va putea da naştere unei infracţiuni, 
-                            sau ar putea conduce la răspunderea civilă, sau ar încălca în alt mod legea. ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE va coopera cu oricare 
-                            dintre autorităţile desemnate să aplice legea şi se va conforma cu orice sentinţă judecătorească prin care se cere sau se ordonă să 
+                        <li className="mb-4">Este interzis să folosiţi site-ul
+                            <HomeLink /> pentru a afişa sau transmite orice fel de material ce are caracter ameninţător, fals, înşelător, abuziv, de hărţuire,
+                            licenţios, calomniator, vulgar, sau orice alt fel de material care poate constitui sau încuraja un comportament ce va putea da naştere unei infracţiuni,
+                            sau ar putea conduce la răspunderea civilă, sau ar încălca în alt mod legea. ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE va coopera cu oricare
+                            dintre autorităţile desemnate să aplice legea şi se va conforma cu orice sentinţă judecătorească prin care se cere sau se ordonă să
                             dezvăluie identitatea oricărei persoane care ar afişa sau transmite orice fel de informaţie sau material de acest fel pe sau prin intermediul site-ului.
                         </li>
-                        <li className="mb-4">Este interzisă redistribuirea vreunei pagini din site prin framing cu excepţia existenţei unui acord scris 
+                        <li className="mb-4">Este interzisă redistribuirea vreunei pagini din site prin framing cu excepţia existenţei unui acord scris
                             din partea asociației cu privire la acceptul redistribuirii vreunei pagini.
                         </li>
-                        <li className="mb-4">Este interzis să utilizaţi site-ul 
-                            <HomeLink/> în scop de publicitate sau pentru orice fel de cerere/ofertă cu caracter comercial fără acordul ASOCIAȚIEI OPORTUNITĂȚI ȘI CARIERE.
+                        <li className="mb-4">Este interzis să utilizaţi site-ul
+                            <HomeLink /> în scop de publicitate sau pentru orice fel de cerere/ofertă cu caracter comercial fără acordul ASOCIAȚIEI OPORTUNITĂȚI ȘI CARIERE.
                         </li>
                         <li className="mb-4">Preluarea de informaţii de către alte site-uri web poate fi făcută numai în acord cu termenii agreaţi şi menţionaţi in această pagina,
-                             cu excepţia unui acord, valabil şi recunoscut de ambele parţi, utilizator şi ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE.
+                            cu excepţia unui acord, valabil şi recunoscut de ambele parţi, utilizator şi ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE.
                         </li>
-                        <li className="mb-4">ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE, logo-ul 
-                            <HomeLink/> şi oricare derivaţie a logo-ului aprobat şi validat sunt proprietatea asociației, niciuna dintre ele neputând 
+                        <li className="mb-4">ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE, logo-ul
+                            <HomeLink /> şi oricare derivaţie a logo-ului aprobat şi validat sunt proprietatea asociației, niciuna dintre ele neputând
                             fi utilizată fără acordul scris al acesteia, indiferent de mediul în care se doreşte utilizarea lui.
                         </li>
                     </ol>
@@ -122,16 +122,16 @@ const TermsOfUse = () => {
                 <section className="pt-12 bg-white/20 w-full flex flex-col items-center" aria-labelledby="responsibilities">
                     <h2 className="text-lg leading-6 text-left mb-4 w-3/4"><strong>3. RĂSPUNDERI</strong></h2>
                     <ol className="mb-8 w-3/4 [list-style-type:lower-alpha] list-inside">
-                        <li className="mb-4">Prin utilizarea site-ului 
-                            <HomeLink/>, dumneavoastră sunteţi singurul responsabil atât faţă de terţi, cât şi faţă de ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE în legătură cu 
-                            accesarea/utilizarea/exploatarea conţinutului. Asociația şi societăţile sale afiliate, funcţionarii, directorii, agenţii sau orice altă 
-                            parte implicată în conceperea, producerea sau oferirea site-ului nu sunt răspunzătoare pentru daune directe sau indirecte, de orice natură, 
-                            ce ar rezulta din sau în legătură cu utilizarea acestui site sau a conţinului său. Asociația nu îşi asumă nicio responsabilitate şi nu va fi 
-                            raspunzătoare pentru nicio daună sau viruşi care ar putea să vă infecteze computerul sau alte bunuri în urma accesării sau utilizării acestui 
+                        <li className="mb-4">Prin utilizarea site-ului
+                            <HomeLink />, dumneavoastră sunteţi singurul responsabil atât faţă de terţi, cât şi faţă de ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE în legătură cu
+                            accesarea/utilizarea/exploatarea conţinutului. Asociația şi societăţile sale afiliate, funcţionarii, directorii, agenţii sau orice altă
+                            parte implicată în conceperea, producerea sau oferirea site-ului nu sunt răspunzătoare pentru daune directe sau indirecte, de orice natură,
+                            ce ar rezulta din sau în legătură cu utilizarea acestui site sau a conţinului său. Asociația nu îşi asumă nicio responsabilitate şi nu va fi
+                            răspunzătoare pentru nicio daună sau viruşi care ar putea să vă infecteze computerul sau alte bunuri în urma accesării sau utilizării acestui
                             site, sau descărcării oricarui material, informaţii, text, imagini, video sau audio de pe acest site.
                         </li>
-                        <li className="mb-4">Utilizarea site-ului reprezintă faptul că declaraţi şi sunteţi de acord cu publicarea de către ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE 
-                            a unui Conţinut, stabilit pe baza unor criterii proprii, Conţinut ce poate fi interpretat ca fiind publicat, prezentat într-o manieră care să 
+                        <li className="mb-4">Utilizarea site-ului reprezintă faptul că declaraţi şi sunteţi de acord cu publicarea de către ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE
+                            a unui Conţinut, stabilit pe baza unor criterii proprii, Conţinut ce poate fi interpretat ca fiind publicat, prezentat într-o manieră care să
                             nu fie conformă cu dorinţele dumneavoastră. Într-un astfel de caz, răspunderea ASOCIAȚIEI OPORTUNITĂȚI ȘI CARIERE nu poate fi reţinută.
                         </li>
                     </ol>
@@ -140,15 +140,15 @@ const TermsOfUse = () => {
                 <section className="pt-12 w-full flex flex-col items-center" aria-labelledby="information-submission">
                     <h2 className="text-lg leading-6 text-left mb-4 w-3/4"><strong>4. TRANSMITEREA DE INFORMAŢII CĂTRE ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE</strong></h2>
                     <ol className="mb-8 w-3/4 [list-style-type:lower-alpha] list-inside">
-                        <li className="mb-4">Prin transmiterea de informaţii către asociație  şi oricare altă societate afiliată si către 
-                            <HomeLink/> se înţelege funizarea de către dumneavoastră a unor materiale, incluzând, dar fără a se limita la mesaje, articole, informaţii, fotografii, date.
+                        <li className="mb-4">Prin transmiterea de informaţii către asociație  şi oricare altă societate afiliată si către
+                            <HomeLink /> se înţelege funizarea de către dumneavoastră a unor materiale, incluzând, dar fără a se limita la mesaje, articole, informaţii, fotografii, date.
                         </li>
-                        <li className="mb-4">Transmiterea de informaţii către 
-                            <HomeLink/> echivalează cu acceptul acordat către ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE şi societăţilor afiliate ca liber de orice obligaţie privind 
+                        <li className="mb-4">Transmiterea de informaţii către
+                            <HomeLink /> echivalează cu acceptul acordat către ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE şi societăţilor afiliate ca liber de orice obligaţie privind
                             achitarea unei plăţi şi/sau remuneraţii, să utilizeze, copieze, publice, distribuie, în orice mod şi cu orice titlu, în orice mediu existent ori descoperit în viitor, aceste informaţii.
                         </li>
-                        <li className="mb-4">Totodată, prin transmiterea de informaţii către ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE, se prezumă acordul dumneavoastră privind despăgubirea 
-                            ASOCIAȚIEI OPORTUNITĂȚI ȘI CARIERE  şi/sau a terţilor ca urmare a existenţei/naşterii unor prejudicii de orice fel din utilizarea, copierea, publicarea 
+                        <li className="mb-4">Totodată, prin transmiterea de informaţii către ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE, se prezumă acordul dumneavoastră privind despăgubirea
+                            ASOCIAȚIEI OPORTUNITĂȚI ȘI CARIERE  şi/sau a terţilor ca urmare a existenţei/naşterii unor prejudicii de orice fel din utilizarea, copierea, publicarea
                             sau distribuirea respectivelor informaţii. ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE nu acceptă o răspundere limitată din partea furnizorului de informaţii.
                         </li>
                     </ol>
@@ -157,8 +157,8 @@ const TermsOfUse = () => {
                 <section className="pt-12 bg-white/20 w-full flex flex-col items-center" aria-labelledby="user-obligations">
                     <h2 className="text-lg leading-6 text-left mb-4 w-3/4"><strong>5. OBLIGATIILE UTILIZATORILOR LA ÎNREGISTRARE</strong></h2>
                     <ol className="mb-8 w-3/4 [list-style-type:lower-alpha] list-inside">
-                        <li className="mb-4">Accesul la conţinutul online al site-ului 
-                            <HomeLink/> este liber.
+                        <li className="mb-4">Accesul la conţinutul online al site-ului
+                            <HomeLink /> este liber.
                         </li>
                     </ol>
                 </section>
@@ -166,33 +166,33 @@ const TermsOfUse = () => {
                 <section className="pt-12 w-full flex flex-col items-center" aria-labelledby="liabilities-indemnities">
                     <h2 className="text-lg leading-6 text-left mb-4 w-3/4"><strong>6. RĂSPUNDERE. DESPĂGUBIRI</strong></h2>
                     <ol className="mb-4 w-3/4 [list-style-type:lower-alpha] list-inside">
-                        <li className="mb-4">Conţinutul acestui site, inclusiv datele şi alte informaţii, este furnizat gratuit de ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE şi 
+                        <li className="mb-4">Conţinutul acestui site, inclusiv datele şi alte informaţii, este furnizat gratuit de ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE şi
                             de către furnizorii săi de informații. Acest site furnizează instrumente de informare, însă nu oferă niciun fel de sfat şi nici nu face vreo
                             recomandare referitoare la anumite locuri de muncă, angajatori sau alte  produse.
                         </li>
-                        <li className="mb-4">ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE nu cere clienţilor săi informaţii personale prin intermediul unei corespondenţe nesolicitate 
-                            de aceştia. Orice tip de corespondenţă care cere divulgarea de informaţii personale trebuie considerat un fals şi raportat către asociație 
+                        <li className="mb-4">ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE nu cere clienţilor săi informaţii personale prin intermediul unei corespondenţe nesolicitate
+                            de aceştia. Orice tip de corespondenţă care cere divulgarea de informaţii personale trebuie considerat un fals şi raportat către asociație
                             prin intermediul adresei de e-mail aocpeviitor@gmail.com
                         </li>
-                        <li>ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE  şi furnizorii săi de conţinut nu răspund pentru erorile, impreciziile sau întârzierile în furnizarea 
+                        <li>ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE  şi furnizorii săi de conţinut nu răspund pentru erorile, impreciziile sau întârzierile în furnizarea
                             conţinutului oferit de site şi nici pentru orice acţiune care se bazează pe acest conţinut. ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE  îşi declină orice
-                            responsabilitate privind garantarea, explicită sau implicită, a acurateţii conţinutului furnizat de terţi sau a felului în care informaţia serveşte anumitor scopuri. 
+                            responsabilitate privind garantarea, explicită sau implicită, a acurateţii conţinutului furnizat de terţi sau a felului în care informaţia serveşte anumitor scopuri.
                             Deşi ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE face toate eforturile pentru a obţine informaţii de încredere de la furnizorii săi externi, nu garantează acurateţea informaţiilor furnizate de aceştia.
-                        </li>     
-                    </ol>    
-                                  
-                    <p className="w-3/4 flex flex-col items-center mb-4">Pentru cazul fortuit, ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE și/sau reprezentantii săi, este exonerata total de răspundere. 
-                        Cazurile fortuite includ, dar nu se limiteaza la, erori de functionare ale echipamentului tehnic, lipsa functionarii conexiunii la internet, lipsa 
-                        functionarii conexiunilor de telefon, virusii informatici, accesul neautorizat in sistemele Site-ului, erorile de operare, etc.
+                        </li>
+                    </ol>
+
+                    <p className="w-3/4 flex flex-col items-center mb-4">Pentru cazul fortuit, ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE și/sau reprezentantii săi, este exonerata total de răspundere.
+                        Cazurile fortuite includ, dar nu se limiteaza la, erori de functionare ale echipamentului tehnic, lipsa funcţionării conexiunii la internet, lipsa
+                        funcţionării conexiunilor de telefon, virusii informatici, accesul neautorizat in sistemele Site-ului, erorile de operare, etc.
                     </p>
 
-                    <ol start="4" className="mb-8 w-3/4 [list-style-type:lower-alpha] list-inside"> 
-                        <li className="mb-4">Fiecare utilizator al site-ului 
-                            <HomeLink/> este de acord ca, la cererea  ASOCIAȚIEI OPORTUNITĂȚI ȘI CARIERE să exonereze de răspundere ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE pentru orice acţiuni judiciare sau extrajudiciare, 
+                    <ol start="4" className="mb-8 w-3/4 [list-style-type:lower-alpha] list-inside">
+                        <li className="mb-4">Fiecare utilizator al site-ului
+                            <HomeLink /> este de acord ca, la cererea  ASOCIAȚIEI OPORTUNITĂȚI ȘI CARIERE să exonereze de răspundere ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE pentru orice acţiuni judiciare sau extrajudiciare,
                             şi să acopere cheltuielile de judecată şi orice alte cheltuieli care ar putea să apară ca urmare a încălcării de către utilizatorul respectiv a clauzelor din prezentul document.
                             Persoanele fizice sau juridice responsabile de încălcarea prevederilor din prezentul document vor suporta prevederile legislaţiei în vigoare în România.
-                            </li>
-                        <li className="mb-4">ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE îşi rezervă dreptul de a modifica şi actualiza aceste condiţii în orice moment. Modificările devin 
+                        </li>
+                        <li className="mb-4">ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE îşi rezervă dreptul de a modifica şi actualiza aceste condiţii în orice moment. Modificările devin
                             efective de la momentul publicării lor pe site.
                         </li>
                     </ol>
@@ -201,7 +201,7 @@ const TermsOfUse = () => {
                 <section className="pt-12 bg-white/20 w-full flex flex-col items-center" aria-labelledby="updates">
                     <h2 className="text-lg leading-6 text-left mb-4 w-3/4"><strong>7. ACTUALIZARE</strong></h2>
                     <ol className="mb-8 w-3/4 [list-style-type:lower-alpha] list-inside">
-                        <li className="mb-4">Aceşti TERMENI ŞI CONDIŢII se actualizeaza de câte ori este nevoie. Modificările se vor reflecta în tipul de informaţii publicate sau transmite de către ASOCIATIE. 
+                        <li className="mb-4">Aceşti TERMENI ŞI CONDIŢII se actualizeaza de câte ori este nevoie. Modificările se vor reflecta în tipul de informaţii publicate sau transmite de către ASOCIATIE.
                             Vă rugăm să citiţi periodic aceste condiţii, pentru a fi la curent cu ce informaţii colectează, foloseşte şi transmite ASOCIATIA OPORTUNITATI SI CARIERE
                         </li>
                     </ol>
@@ -212,7 +212,7 @@ const TermsOfUse = () => {
                     <ol className="mb-8 w-3/4 [list-style-type:lower-alpha] list-inside">
                         <li className="mb-4">Prezentului acord, precum și oricărei utilizări a site-ului li se vor aplica legea română. Orice litigiu va fi supus spre soluționare instanțelor române.</li>
                     </ol>
-                </section>           
+                </section>
             </article>
         </Layout>
     );

--- a/src/pages/TermsOfUse.jsx
+++ b/src/pages/TermsOfUse.jsx
@@ -57,7 +57,7 @@ const TermsOfUse = () => {
                 <section className="pt-12 bg-white/20 w-full flex flex-col items-center" aria-labelledby="content-heading">
                     <h2 className="text-lg leading-6 text-left mb-4 w-3/4"><strong>1. CONŢINUTUL</strong></h2>
                     <ol className="mb-8 w-3/4 [list-style-type:lower-alpha] list-inside">
-                        <li className="mb-4">Conţinutul site-ului este destinat uzului personal, fără scop direct ori indirect comercial. Toate materialele publicate (incluzând, dar fără a se limita la,
+                        <li className="mb-4">Conţinutul site-ului este destinat uzului personal, fără scop direct ori indirect comercial. Toate materialele publicate (incluzând, dar fără a se limita la
                             articole, informaţii, fotografii, date, clipuri audio/video – generic numite conţinut) sunt protejate de dispoziţiile legale incidente: Legea nr. 8/1996, cu modificările şi completările
                             ulterioare – privind dreptul de autor şi drepturile conexe, Legea nr. 84/1998 – privind mărcile şi indicaţiile geografice şi Legea nr. 129/1992, republicată – privind protecţia
                             desenelor şi modelelor. Lipsa menţiunii privind unele texte legale ori dispoziţii incidente nu duc la inaplicabilitatea acestora.
@@ -75,7 +75,7 @@ const TermsOfUse = () => {
                         <li className="mb-4">În cazul în care consideraţi că orice material publicat pe acest site oricine altcineva încalcă drepturile de autor sau orice alte drepturi,
                             vă rugăm să ne sesizaţi acest lucru printr-un mesaj trimis la adresa publicată în secţiunea Contact a site-ului sau pe adresa de e-mail aocpeviitor@gmail.com
                         </li>
-                        <li className="mb-4">Vă informăm că ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE îşi va asigura şi impune în mod hotărît recunoaşterea drepturilor de proprietate intelectuală
+                        <li className="mb-4">Vă informăm că ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE îşi va asigura şi impune în mod hotărât recunoaşterea drepturilor de proprietate intelectuală
                             în conformitate cu legile în vigoare, ajungând dacă este cazul, la acţionarea în judecată a celor vinovaţi de încălcarea dreptului de proprietate intelectuală.
                         </li>
                     </ol>
@@ -181,9 +181,9 @@ const TermsOfUse = () => {
                         </li>
                     </ol>
 
-                    <p className="w-3/4 flex flex-col items-center mb-4">Pentru cazul fortuit, ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE și/sau reprezentantii săi, este exonerata total de răspundere.
-                        Cazurile fortuite includ, dar nu se limiteaza la, erori de functionare ale echipamentului tehnic, lipsa funcţionării conexiunii la internet, lipsa
-                        funcţionării conexiunilor de telefon, virusii informatici, accesul neautorizat in sistemele Site-ului, erorile de operare, etc.
+                    <p className="w-3/4 flex flex-col items-center mb-4">Pentru cazul fortuit, ASOCIAȚIA OPORTUNITĂȚI ȘI CARIERE și/sau reprezentanții săi, este exonerată total de răspundere.
+                        Cazurile fortuite includ, dar nu se limitează la: erori de funcționare ale echipamentului tehnic, lipsa funcţionării conexiunii la internet, lipsa
+                        funcţionării conexiunilor de telefon, virușii informatici, accesul neautorizat în sistemele site-ului, erorile de operare, etc.
                     </p>
 
                     <ol start="4" className="mb-8 w-3/4 [list-style-type:lower-alpha] list-inside">


### PR DESCRIPTION
I resolved the bug on the "Condiţii de utilizare" page by correcting spelling errors and adding missing diacritics. 
Expected result/ Corrected spelling : 
![image](https://github.com/user-attachments/assets/34df46a7-c6c9-4ed1-bb98-5acdc156d86a)

![image](https://github.com/user-attachments/assets/bbf73a25-26be-4b6d-a619-f72a060d9a55)

![image](https://github.com/user-attachments/assets/e366537c-2dfe-480c-aad2-f7b1662a8234)

![image](https://github.com/user-attachments/assets/ab4f31e2-1335-472d-ba71-17d7322bbce8)
