### PR TITLE
fix: switched result card layout for location icon and city name/s

### DIFF
--- a/src/components/Job.jsx
+++ b/src/components/Job.jsx
@@ -48,8 +48,8 @@ const Job = ({ city, company, county, job_link, job_title, remote }) => {
         <h2 className="text-lg font-bold truncate" title={job_title}>
           {job_title}
         </h2>
-        <div className="flex items-center justify-center gap-1">
-          <img src={mapPin} alt="map pin" className="w-auto h-[16px]" />
+        <div className="flex flex-col items-center justify-center gap-1">
+          <img src={mapPin} alt="map pin" className="w-auto h-[18px]" />
           <p>{city || remote ? displayLocation(city) : ""}</p>
         </div>
 


### PR DESCRIPTION
Changed element directions for location icon and location names.

**Old:**
<img width="1355" height="847" alt="image" src="https://github.com/user-attachments/assets/756d3895-c227-44fb-b053-0e431d62c30e" />

**New:**
<img width="1920" height="918" alt="image" src="https://github.com/user-attachments/assets/f9ae058e-af4e-4881-aacf-aeb5f8907277" />
